### PR TITLE
Experimental field interp numpy

### DIFF
--- a/src/espic/interp_field.py
+++ b/src/espic/interp_field.py
@@ -22,7 +22,7 @@ class InterpolateField:
         ids = [(np.abs(grid - coord)).argmin() for (coord, grid) in zip(coords, self.grids)]
         return tuple(ids)
 
-    def ev(self, coords):
+    def evaluate(self, coords):
         coords = np.asarray(coords)
         ids = self.find_nearest_spatial_node(coords)
         return [ar[ids] for ar in self.E_on_grid]

--- a/src/espic/interp_field.py
+++ b/src/espic/interp_field.py
@@ -4,16 +4,25 @@ import numpy as np
 
 
 class InterpolateField:
-    def __init__(self, grids, phi_on_grid):
-        # grids is a list of arrays, phi_on_grid is an array
+    def __init__(self, grids, phi_on_grid, indexing='xy'):
+        # grids is a list of arrays (x or x,y), phi_on_grid is an array (x or x,y)
+        # phi_on_grid indexed in the standard np.meshgrid way, and this is what 'indexing' refers to
         self.grids = grids
         self.phi_on_grid = phi_on_grid
+        self.indexing = indexing
         
         # We need to ensure that E_on_grid is a list of arrays
         if len(self.grids) == 1:
             self.E_on_grid = [-1 * np.gradient(self.phi_on_grid, *self.grids)]
         else:
-            self.E_on_grid = [-1 * ar for ar in np.gradient(self.phi_on_grid, *self.grids)]
+            # FIXME reverse or not??? Write tests!!
+            if self.indexing == 'xy':
+                # We must reverse the order of the np.gradient output to match our desired form
+                self.E_on_grid = list(reversed([-1 * ar for ar in np.gradient(self.phi_on_grid, *self.grids)]))
+            elif self.indexing == 'ij':
+                self.E_on_grid = [-1 * ar for ar in np.gradient(self.phi_on_grid, *self.grids)]
+            else:
+                raise ValueError("Valid values for `indexing` are 'xy' and 'ij'.")
     
     def find_nearest_spatial_node(self, coords):
         # Coords should be 1D numpy array

--- a/src/espic/interp_field.py
+++ b/src/espic/interp_field.py
@@ -4,25 +4,17 @@ import numpy as np
 
 
 class InterpolateField:
-    def __init__(self, grids, phi_on_grid, indexing='xy'):
+    def __init__(self, grids, phi_on_grid):
         # grids is a list of arrays (x or x,y), phi_on_grid is an array (x or x,y)
-        # phi_on_grid indexed in the standard np.meshgrid way, and this is what 'indexing' refers to
+        # phi_on_grid indexed in the np.meshgrid way *with indexing='ij'*. The default will not work!!
         self.grids = grids
         self.phi_on_grid = phi_on_grid
-        self.indexing = indexing
         
         # We need to ensure that E_on_grid is a list of arrays
         if len(self.grids) == 1:
             self.E_on_grid = [-1 * np.gradient(self.phi_on_grid, *self.grids)]
         else:
-            # FIXME reverse or not??? Write tests!!
-            if self.indexing == 'xy':
-                # We must reverse the order of the np.gradient output to match our desired form
-                self.E_on_grid = list(reversed([-1 * ar for ar in np.gradient(self.phi_on_grid, *self.grids)]))
-            elif self.indexing == 'ij':
-                self.E_on_grid = [-1 * ar for ar in np.gradient(self.phi_on_grid, *self.grids)]
-            else:
-                raise ValueError("Valid values for `indexing` are 'xy' and 'ij'.")
+            self.E_on_grid = [-1 * ar for ar in np.gradient(self.phi_on_grid, *self.grids)]
     
     def find_nearest_spatial_node(self, coords):
         # Coords should be 1D numpy array

--- a/src/espic/make_weight_func.py
+++ b/src/espic/make_weight_func.py
@@ -15,5 +15,4 @@ class ChargeWeightFunc:
             < self.spatial_grid_delta / 2
         ):
             return 1 / self.spatial_grid_delta
-        else:
-            return 0
+        return 0

--- a/tests/test_interp_field.py
+++ b/tests/test_interp_field.py
@@ -3,12 +3,21 @@
 import numpy as np
 from espic.interp_field import InterpolateField
 
+def test_interpolate_field_1D_null_field():
+    x_vec = np.linspace(0, 1, num=10)
+    phi_on_grid = np.ones(x_vec.size)
+    interpolated_field = InterpolateField([x_vec], phi_on_grid)
+    evaluated_field = interpolated_field.ev([0.5])
+    target_field = np.asarray([0])
+
+    assert np.allclose(evaluated_field, target_field)
+
 def test_interpolate_field_2D_null_field():
     x_vec = np.linspace(0, 1, num=10)
     y_vec = x_vec
     phi_on_grid = np.ones((x_vec.size, y_vec.size)) # Constant potential, so should give zero electric field
-    interpolated_field = InterpolateField(y_vec, x_vec, phi_on_grid) # Order switched due to convention difference
-    evaluated_field = interpolated_field.calc_field(0.55, 0.55)
+    interpolated_field = InterpolateField([x_vec, y_vec], phi_on_grid)
+    evaluated_field = interpolated_field.ev([0.5, 0.5])
     target_field = np.asarray([0, 0])
 
     assert np.allclose(evaluated_field, target_field)
@@ -19,15 +28,16 @@ def test_interpolate_field_2D_linear_potential():
     xx, yy = np.meshgrid(x_vec, y_vec)
     zz1 = xx
     zz2 = yy
-    interpolated_field1 = InterpolateField(y_vec, x_vec, zz1) # Order switched due to convention difference
-    interpolated_field2 = InterpolateField(y_vec, x_vec, zz2)
-    evaluated_field1 = interpolated_field1.calc_field(0.55, 0.55)
-    evaluated_field2 = interpolated_field2.calc_field(0.55, 0.55)
+    interpolated_field1 = InterpolateField([x_vec, y_vec], zz1)
+    interpolated_field2 = InterpolateField([x_vec, y_vec], zz2)
+    evaluated_field1 = interpolated_field1.ev([0.5, 0.5])
+    evaluated_field2 = interpolated_field2.ev([0.5, 0.5])
     target_field1 = np.asarray([-1, 0])
     target_field2 = np.asarray([0, -1])
 
     assert np.allclose(evaluated_field1, target_field1)
     assert np.allclose(evaluated_field2, target_field2)
+'''
 
 def test_interpolate_field_2D_parabolic_potential():
     x_vec = np.linspace(-2, 2, num=1000)
@@ -68,3 +78,9 @@ def test_interpolate_field_2D_semiparabolic_potential():
     assert np.allclose(evaluated_field2, target_field2)
     assert np.allclose(evaluated_field3, target_field3)
     assert np.allclose(evaluated_field4, target_field4)
+'''
+
+if __name__ == '__main__':
+    test_interpolate_field_1D_null_field()
+    test_interpolate_field_2D_null_field()
+    test_interpolate_field_2D_linear_potential()

--- a/tests/test_interp_field.py
+++ b/tests/test_interp_field.py
@@ -15,7 +15,7 @@ def test_interpolate_field_1D_null_field():
 def test_interpolate_field_2D_null_field():
     x_vec = np.linspace(0, 1, num=10)
     y_vec = x_vec
-    phi_on_grid = np.ones((x_vec.size, y_vec.size)) # Constant potential, so should give zero electric field
+    phi_on_grid = np.ones((x_vec.size, y_vec.size))
     interpolated_field = InterpolateField([x_vec, y_vec], phi_on_grid)
     evaluated_field = interpolated_field.ev([0.5, 0.5])
     target_field = np.asarray([0, 0])
@@ -23,41 +23,74 @@ def test_interpolate_field_2D_null_field():
     assert np.allclose(evaluated_field, target_field)
 
 def test_interpolate_field_2D_linear_potential():
+    indexing1 = 'xy'
+    indexing2 = 'ij'
     x_vec = np.linspace(0, 1, num=100)
     y_vec = x_vec
-    xx, yy = np.meshgrid(x_vec, y_vec)
-    zz1 = xx
-    zz2 = yy
-    interpolated_field1 = InterpolateField([x_vec, y_vec], zz1)
-    interpolated_field2 = InterpolateField([x_vec, y_vec], zz2)
+    xx1, _ = np.meshgrid(x_vec, y_vec, indexing=indexing1)
+    xx2, _ = np.meshgrid(x_vec, y_vec, indexing=indexing2)
+    zz1 = xx1
+    zz2 = xx2
+    interpolated_field1 = InterpolateField([x_vec, y_vec], zz1, indexing=indexing1)
+    interpolated_field2 = InterpolateField([x_vec, y_vec], zz2, indexing=indexing2)
     evaluated_field1 = interpolated_field1.ev([0.5, 0.5])
     evaluated_field2 = interpolated_field2.ev([0.5, 0.5])
-    target_field1 = np.asarray([-1, 0])
-    target_field2 = np.asarray([0, -1])
+    target_field = np.asarray([-1, 0])
 
-    assert np.allclose(evaluated_field1, target_field1)
-    assert np.allclose(evaluated_field2, target_field2)
-'''
+    assert np.allclose(evaluated_field1, target_field)
+    assert np.allclose(evaluated_field2, target_field)
 
 def test_interpolate_field_2D_parabolic_potential():
+    indexing1 = 'xy'
+    indexing2 = 'ij'
     x_vec = np.linspace(-2, 2, num=1000)
     y_vec = x_vec
-    xx, yy = np.meshgrid(x_vec, y_vec)
-    zz = xx**2 + yy**2
-    interpolated_field = InterpolateField(y_vec, x_vec, zz) # Order switched due to convention difference
-    evaluated_field1 = interpolated_field.calc_field(0, 0)
-    evaluated_field2 = interpolated_field.calc_field(-1, 1)
-    evaluated_field3 = interpolated_field.calc_field(1.5, -1.5)
-    evaluated_field4 = interpolated_field.calc_field(0.5, 1)
+    xx1, yy1 = np.meshgrid(x_vec, y_vec, indexing=indexing1)
+    xx2, yy2 = np.meshgrid(x_vec, y_vec, indexing=indexing2)
+    zz1 = xx1**2 + yy1**2
+    zz2 = xx2**2 + yy2**2
+    interpolated_field1 = InterpolateField([x_vec, y_vec], zz1, indexing=indexing1)
+    interpolated_field2 = InterpolateField([x_vec, y_vec], zz2, indexing=indexing2)
+    evaluated_field11 = interpolated_field1.ev([0, 0])
+    evaluated_field12 = interpolated_field1.ev([-1, 1])
+    evaluated_field13 = interpolated_field1.ev([1.5, -1.5])
+    evaluated_field14 = interpolated_field1.ev([0.5, 1])
+    evaluated_field21 = interpolated_field2.ev([0, 0])
+    evaluated_field22 = interpolated_field2.ev([-1, 1])
+    evaluated_field23 = interpolated_field2.ev([1.5, -1.5])
+    evaluated_field24 = interpolated_field2.ev([0.5, 1])
     target_field1 = np.asarray([0, 0])
     target_field2 = np.asarray([2, -2])
     target_field3 = np.asarray([-3, 3])
     target_field4 = np.asarray([-1, -2])
-    
-    assert np.allclose(evaluated_field1, target_field1)
-    assert np.allclose(evaluated_field2, target_field2)
-    assert np.allclose(evaluated_field3, target_field3)
-    assert np.allclose(evaluated_field4, target_field4)
+
+    print(evaluated_field12)
+    print(evaluated_field22)
+    quit()
+
+    print(evaluated_field11)
+    print(target_field1)
+    print(evaluated_field12)
+    print(target_field2)
+    print(evaluated_field13)
+    print(target_field3)
+    print(evaluated_field14)
+    print(target_field4)
+
+    assert np.allclose(evaluated_field11, evaluated_field21)
+    assert np.allclose(evaluated_field12, evaluated_field22)
+    assert np.allclose(evaluated_field13, evaluated_field23)
+    assert np.allclose(evaluated_field14, evaluated_field24)
+    assert np.allclose(evaluated_field11, target_field1)
+    assert np.allclose(evaluated_field12, target_field2)
+    assert np.allclose(evaluated_field13, target_field3)
+    assert np.allclose(evaluated_field14, target_field4)
+    assert np.allclose(evaluated_field21, target_field1)
+    assert np.allclose(evaluated_field22, target_field2)
+    assert np.allclose(evaluated_field23, target_field3)
+    assert np.allclose(evaluated_field24, target_field4)
+
+'''
 
 def test_interpolate_field_2D_semiparabolic_potential():
     x_vec = np.linspace(-2, 2, num=1000)
@@ -84,3 +117,4 @@ if __name__ == '__main__':
     test_interpolate_field_1D_null_field()
     test_interpolate_field_2D_null_field()
     test_interpolate_field_2D_linear_potential()
+    test_interpolate_field_2D_parabolic_potential()

--- a/tests/test_interp_field.py
+++ b/tests/test_interp_field.py
@@ -12,6 +12,19 @@ def test_interpolate_field_1D_null_field():
 
     assert np.allclose(evaluated_field, target_field)
 
+def test_interpolate_field_1D_linear_potential():
+    x_vec = np.linspace(0, 1, num=10)
+    phi_on_grid = 3 * x_vec
+    interpolated_field = InterpolateField([x_vec], phi_on_grid)
+    evaluated_field1 = interpolated_field.ev([0])
+    evaluated_field2 = interpolated_field.ev([0.5])
+    evaluated_field3 = interpolated_field.ev([1])
+    target_field = np.asarray([-3])
+
+    assert np.allclose(evaluated_field1, target_field)
+    assert np.allclose(evaluated_field2, target_field)
+    assert np.allclose(evaluated_field3, target_field)
+
 def test_interpolate_field_2D_null_field():
     x_vec = np.linspace(0, 1, num=10)
     y_vec = x_vec
@@ -23,98 +36,57 @@ def test_interpolate_field_2D_null_field():
     assert np.allclose(evaluated_field, target_field)
 
 def test_interpolate_field_2D_linear_potential():
-    indexing1 = 'xy'
-    indexing2 = 'ij'
     x_vec = np.linspace(0, 1, num=100)
     y_vec = x_vec
-    xx1, _ = np.meshgrid(x_vec, y_vec, indexing=indexing1)
-    xx2, _ = np.meshgrid(x_vec, y_vec, indexing=indexing2)
-    zz1 = xx1
-    zz2 = xx2
-    interpolated_field1 = InterpolateField([x_vec, y_vec], zz1, indexing=indexing1)
-    interpolated_field2 = InterpolateField([x_vec, y_vec], zz2, indexing=indexing2)
+    xx, yy = np.meshgrid(x_vec, y_vec, indexing='ij')
+    zz1 = xx
+    zz2 = yy
+    interpolated_field1 = InterpolateField([x_vec, y_vec], zz1)
+    interpolated_field2 = InterpolateField([x_vec, y_vec], zz2)
     evaluated_field1 = interpolated_field1.ev([0.5, 0.5])
     evaluated_field2 = interpolated_field2.ev([0.5, 0.5])
-    target_field = np.asarray([-1, 0])
+    target_field1 = np.asarray([-1, 0])
+    target_field2 = np.asarray([0, -1])
 
-    assert np.allclose(evaluated_field1, target_field)
-    assert np.allclose(evaluated_field2, target_field)
+    assert np.allclose(evaluated_field1, target_field1)
+    assert np.allclose(evaluated_field2, target_field2)
 
 def test_interpolate_field_2D_parabolic_potential():
-    indexing1 = 'xy'
-    indexing2 = 'ij'
     x_vec = np.linspace(-2, 2, num=1000)
     y_vec = x_vec
-    xx1, yy1 = np.meshgrid(x_vec, y_vec, indexing=indexing1)
-    xx2, yy2 = np.meshgrid(x_vec, y_vec, indexing=indexing2)
-    zz1 = xx1**2 + yy1**2
-    zz2 = xx2**2 + yy2**2
-    interpolated_field1 = InterpolateField([x_vec, y_vec], zz1, indexing=indexing1)
-    interpolated_field2 = InterpolateField([x_vec, y_vec], zz2, indexing=indexing2)
-    evaluated_field11 = interpolated_field1.ev([0, 0])
-    evaluated_field12 = interpolated_field1.ev([-1, 1])
-    evaluated_field13 = interpolated_field1.ev([1.5, -1.5])
-    evaluated_field14 = interpolated_field1.ev([0.5, 1])
-    evaluated_field21 = interpolated_field2.ev([0, 0])
-    evaluated_field22 = interpolated_field2.ev([-1, 1])
-    evaluated_field23 = interpolated_field2.ev([1.5, -1.5])
-    evaluated_field24 = interpolated_field2.ev([0.5, 1])
+    xx, yy = np.meshgrid(x_vec, y_vec, indexing='ij')
+    zz = xx**2 + yy**2
+    interpolated_field = InterpolateField([x_vec, y_vec], zz)
+    evaluated_field1 = interpolated_field.ev([0, 0])
+    evaluated_field2 = interpolated_field.ev([-1, 1])
+    evaluated_field3 = interpolated_field.ev([1.5, -1.5])
+    evaluated_field4 = interpolated_field.ev([0.5, 1])
     target_field1 = np.asarray([0, 0])
     target_field2 = np.asarray([2, -2])
     target_field3 = np.asarray([-3, 3])
     target_field4 = np.asarray([-1, -2])
-
-    print(evaluated_field12)
-    print(evaluated_field22)
-    quit()
-
-    print(evaluated_field11)
-    print(target_field1)
-    print(evaluated_field12)
-    print(target_field2)
-    print(evaluated_field13)
-    print(target_field3)
-    print(evaluated_field14)
-    print(target_field4)
-
-    assert np.allclose(evaluated_field11, evaluated_field21)
-    assert np.allclose(evaluated_field12, evaluated_field22)
-    assert np.allclose(evaluated_field13, evaluated_field23)
-    assert np.allclose(evaluated_field14, evaluated_field24)
-    assert np.allclose(evaluated_field11, target_field1)
-    assert np.allclose(evaluated_field12, target_field2)
-    assert np.allclose(evaluated_field13, target_field3)
-    assert np.allclose(evaluated_field14, target_field4)
-    assert np.allclose(evaluated_field21, target_field1)
-    assert np.allclose(evaluated_field22, target_field2)
-    assert np.allclose(evaluated_field23, target_field3)
-    assert np.allclose(evaluated_field24, target_field4)
-
-'''
+    
+    assert np.allclose(evaluated_field1, target_field1, atol=5e-3, rtol=0)
+    assert np.allclose(evaluated_field2, target_field2, atol=5e-3, rtol=0)
+    assert np.allclose(evaluated_field3, target_field3, atol=5e-3, rtol=0)
+    assert np.allclose(evaluated_field4, target_field4, atol=5e-3, rtol=0)
 
 def test_interpolate_field_2D_semiparabolic_potential():
     x_vec = np.linspace(-2, 2, num=1000)
     y_vec = x_vec
-    xx, yy = np.meshgrid(x_vec, y_vec)
+    xx, yy = np.meshgrid(x_vec, y_vec, indexing='ij')
     zz = xx**2 - 2 * yy**2
-    interpolated_field = InterpolateField(y_vec, x_vec, zz) # Order switched due to convention difference
-    evaluated_field1 = interpolated_field.calc_field(0, 0)
-    evaluated_field2 = interpolated_field.calc_field(-1, 1)
-    evaluated_field3 = interpolated_field.calc_field(1.5, -1.5)
-    evaluated_field4 = interpolated_field.calc_field(0.5, 1)
+    interpolated_field = InterpolateField([x_vec, y_vec], zz) # Order switched due to convention difference
+    evaluated_field1 = interpolated_field.ev([0, 0])
+    evaluated_field2 = interpolated_field.ev([-1, 1])
+    evaluated_field3 = interpolated_field.ev([1.5, -1.5])
+    evaluated_field4 = interpolated_field.ev([0.5, 1])
     target_field1 = np.asarray([0, 0])
     target_field2 = np.asarray([2, 4])
     target_field3 = np.asarray([-3, -6])
     target_field4 = np.asarray([-1, 4])
     
-    assert np.allclose(evaluated_field1, target_field1)
-    assert np.allclose(evaluated_field2, target_field2)
-    assert np.allclose(evaluated_field3, target_field3)
-    assert np.allclose(evaluated_field4, target_field4)
-'''
-
-if __name__ == '__main__':
-    test_interpolate_field_1D_null_field()
-    test_interpolate_field_2D_null_field()
-    test_interpolate_field_2D_linear_potential()
-    test_interpolate_field_2D_parabolic_potential()
+    assert np.allclose(evaluated_field1, target_field1, atol=9e-3, rtol=0)
+    assert np.allclose(evaluated_field2, target_field2, atol=9e-3, rtol=0)
+    assert np.allclose(evaluated_field3, target_field3, atol=9e-3, rtol=0)
+    assert np.allclose(evaluated_field4, target_field4, atol=9e-3, rtol=0)

--- a/tests/test_interp_field.py
+++ b/tests/test_interp_field.py
@@ -7,7 +7,7 @@ def test_interpolate_field_1D_null_field():
     x_vec = np.linspace(0, 1, num=10)
     phi_on_grid = np.ones(x_vec.size)
     interpolated_field = InterpolateField([x_vec], phi_on_grid)
-    evaluated_field = interpolated_field.ev([0.5])
+    evaluated_field = interpolated_field.evaluate([0.5])
     target_field = np.asarray([0])
 
     assert np.allclose(evaluated_field, target_field)
@@ -16,9 +16,9 @@ def test_interpolate_field_1D_linear_potential():
     x_vec = np.linspace(0, 1, num=10)
     phi_on_grid = 3 * x_vec
     interpolated_field = InterpolateField([x_vec], phi_on_grid)
-    evaluated_field1 = interpolated_field.ev([0])
-    evaluated_field2 = interpolated_field.ev([0.5])
-    evaluated_field3 = interpolated_field.ev([1])
+    evaluated_field1 = interpolated_field.evaluate([0])
+    evaluated_field2 = interpolated_field.evaluate([0.5])
+    evaluated_field3 = interpolated_field.evaluate([1])
     target_field = np.asarray([-3])
 
     assert np.allclose(evaluated_field1, target_field)
@@ -30,7 +30,7 @@ def test_interpolate_field_2D_null_field():
     y_vec = x_vec
     phi_on_grid = np.ones((x_vec.size, y_vec.size))
     interpolated_field = InterpolateField([x_vec, y_vec], phi_on_grid)
-    evaluated_field = interpolated_field.ev([0.5, 0.5])
+    evaluated_field = interpolated_field.evaluate([0.5, 0.5])
     target_field = np.asarray([0, 0])
 
     assert np.allclose(evaluated_field, target_field)
@@ -43,8 +43,8 @@ def test_interpolate_field_2D_linear_potential():
     zz2 = yy
     interpolated_field1 = InterpolateField([x_vec, y_vec], zz1)
     interpolated_field2 = InterpolateField([x_vec, y_vec], zz2)
-    evaluated_field1 = interpolated_field1.ev([0.5, 0.5])
-    evaluated_field2 = interpolated_field2.ev([0.5, 0.5])
+    evaluated_field1 = interpolated_field1.evaluate([0.5, 0.5])
+    evaluated_field2 = interpolated_field2.evaluate([0.5, 0.5])
     target_field1 = np.asarray([-1, 0])
     target_field2 = np.asarray([0, -1])
 
@@ -57,10 +57,10 @@ def test_interpolate_field_2D_parabolic_potential():
     xx, yy = np.meshgrid(x_vec, y_vec, indexing='ij')
     zz = xx**2 + yy**2
     interpolated_field = InterpolateField([x_vec, y_vec], zz)
-    evaluated_field1 = interpolated_field.ev([0, 0])
-    evaluated_field2 = interpolated_field.ev([-1, 1])
-    evaluated_field3 = interpolated_field.ev([1.5, -1.5])
-    evaluated_field4 = interpolated_field.ev([0.5, 1])
+    evaluated_field1 = interpolated_field.evaluate([0, 0])
+    evaluated_field2 = interpolated_field.evaluate([-1, 1])
+    evaluated_field3 = interpolated_field.evaluate([1.5, -1.5])
+    evaluated_field4 = interpolated_field.evaluate([0.5, 1])
     target_field1 = np.asarray([0, 0])
     target_field2 = np.asarray([2, -2])
     target_field3 = np.asarray([-3, 3])
@@ -77,10 +77,10 @@ def test_interpolate_field_2D_semiparabolic_potential():
     xx, yy = np.meshgrid(x_vec, y_vec, indexing='ij')
     zz = xx**2 - 2 * yy**2
     interpolated_field = InterpolateField([x_vec, y_vec], zz) # Order switched due to convention difference
-    evaluated_field1 = interpolated_field.ev([0, 0])
-    evaluated_field2 = interpolated_field.ev([-1, 1])
-    evaluated_field3 = interpolated_field.ev([1.5, -1.5])
-    evaluated_field4 = interpolated_field.ev([0.5, 1])
+    evaluated_field1 = interpolated_field.evaluate([0, 0])
+    evaluated_field2 = interpolated_field.evaluate([-1, 1])
+    evaluated_field3 = interpolated_field.evaluate([1.5, -1.5])
+    evaluated_field4 = interpolated_field.evaluate([0.5, 1])
     target_field1 = np.asarray([0, 0])
     target_field2 = np.asarray([2, 4])
     target_field3 = np.asarray([-3, -6])


### PR DESCRIPTION
I fixed electric potential interpolation and implemented it using finite difference gradients rather than spline interpolation. Finite differences are considerably faster and should be accurate enough for our purposes. The result is a way to calculate the electric field on the spatial grid in arbitrary dimensions.